### PR TITLE
Use resampling when blitting if set to by properties

### DIFF
--- a/dist/Data/Runtime/Html5/Surface.js
+++ b/dist/Data/Runtime/Html5/Surface.js
@@ -616,6 +616,11 @@ OSurface.prototype = {
         var t = document.createElement("canvas").getContext("2d");
         t.canvas.width = h;
         t.canvas.height = e;
+        let gq = this.blit.stretchMode >= 2;
+        t["mozImageSmoothingEnabled"] = t["webkitImageSmoothingEnabled"] = t["msImageSmoothingEnabled"] = t["imageSmoothingEnabled"] = gq;
+        if (gq) {
+            t["imageSmoothingQuality"] = "high";
+        }
         t.drawImage(b, m, n, k, l, 0, 0, h, e);
         switch (this.blit.effect) {
             case OSurface.BLIT_EFFECT_AND:
@@ -626,7 +631,12 @@ OSurface.prototype = {
         }
         if ("" != this.blit.callback || d) {
             a.save();
-            0 != r ? (b = document.createElement("canvas").getContext("2d"), b.canvas.width = h, b.canvas.height = e, b.translate(p, q), b.rotate(r), b.translate(-p, -q), b.drawImage(a.canvas, f - p, g - q, h, e, 0, 0, h, e), b = b.getImageData(0, 0, h, e)) : b = a.getImageData(f - p, g - q, h, e);
+			let b = b = document.createElement("canvas").getContext("2d");
+			b["mozImageSmoothingEnabled"] = b["webkitImageSmoothingEnabled"] = b["msImageSmoothingEnabled"] = b["imageSmoothingEnabled"] = gq;
+			if (gq) {
+				b["imageSmoothingQuality"] = "high";
+			}
+            0 != r ? (b.canvas.width = h, b.canvas.height = e, b.translate(p, q), b.rotate(r), b.translate(-p, -q), b.drawImage(a.canvas, f - p, g - q, h, e, 0, 0, h, e), b = b.getImageData(0, 0, h, e)) : b = a.getImageData(f - p, g - q, h, e);
             b = b.data;
             k = t.getImageData(0, 0, h, e);
             l = k.data;

--- a/src/Surface.js
+++ b/src/Surface.js
@@ -1343,6 +1343,14 @@ OSurface.prototype = {
         tmpSourceContext.canvas.width = dw;
         tmpSourceContext.canvas.height = dh;
 
+        let goodQuality = this.blit.stretchMode >= 2;
+        tmpSourceContext["mozImageSmoothingEnabled"] = goodQuality;
+        tmpSourceContext["webkitImageSmoothingEnabled"] = goodQuality;
+        tmpSourceContext["msImageSmoothingEnabled"] = goodQuality;
+        tmpSourceContext["imageSmoothingEnabled"] = goodQuality;
+        if (goodQuality) {
+            tmpSourceContext["imageSmoothingQuality"] = "high";
+        }
         tmpSourceContext.drawImage(sourceCanvas, sx, sy, sw, sh, 0, 0, dw, dh);
 
         switch (this.blit.effect) {
@@ -1363,6 +1371,13 @@ OSurface.prototype = {
                 var tmpDestContext = document.createElement("canvas").getContext("2d");
                 tmpDestContext.canvas.width = dw;
                 tmpDestContext.canvas.height = dh;
+                tmpDestContext["mozImageSmoothingEnabled"] = goodQuality;
+                tmpDestContext["webkitImageSmoothingEnabled"] = goodQuality;
+                tmpDestContext["msImageSmoothingEnabled"] = goodQuality;
+                tmpDestContext["imageSmoothingEnabled"] = goodQuality;
+                if (goodQuality) {
+                    tmpDestContext["imageSmoothingQuality"] = "high";
+                }
                 tmpDestContext.translate(hotX, hotY);
                 tmpDestContext.rotate(angle);
                 tmpDestContext.translate(-hotX, -hotY);


### PR DESCRIPTION
It's only a minor difference, but useful.

The other mistake was the minified file reading variable from a class's variable's variable, rather than class's variable. I can't see why it would generate that from this repo's code, so maybe it was already fixed?
