### PR TITLE
Fusion b296.1 compatibility fixes

### DIFF
--- a/dist/Data/Runtime/Html5/Surface.js
+++ b/dist/Data/Runtime/Html5/Surface.js
@@ -298,7 +298,7 @@ OSurface.prototype = {
         a.context.drawImage(c.canvas, -d, 0);
         this.redraw();
     }, setAngle: function (b) {
-        img.rotation = b;
+        this.imageList[this.selectedImage].rotation = b;
         this.redraw();
     }, setContrast: function (b) {
         for (var a = this.imageList[this.selectedImage], d = a.context.getImageData(0, 0, a.canvas.width, a.canvas.width), c = d.data, f = 0; f < c.length; f += 4) {

--- a/dist/Data/Runtime/Html5/Surface.js
+++ b/dist/Data/Runtime/Html5/Surface.js
@@ -172,9 +172,7 @@ OSurface.prototype = {
         if (this.hasImageIndex(b)) {
             var c = a >>> 16 & 255, f = a >>> 8 & 255;
             a &= 255;
-            newRed = d >>> 16 & 255;
-            newGreen = d >>> 8 & 255;
-            newBlue = d & 255;
+            var newRed = d >>> 16 & 255, newGreen = d >>> 8 & 255, newBlue = d & 255;
             for (var g = this.imageList[b].context.getImageData(0, 0, this.imageList[b].getWidth(), this.imageList[b].getHeight()), h = 0; h < g.data.length; h += 4) {
                 g.data[h] == c && g.data[h + 1] == f && g.data[h + 2] == a && (g.data[h] = newRed, g.data[h + 1] = newGreen, g.data[h + 2] = newBlue);
             }
@@ -631,7 +629,7 @@ OSurface.prototype = {
         }
         if ("" != this.blit.callback || d) {
             a.save();
-			let b = b = document.createElement("canvas").getContext("2d");
+			let b = document.createElement("canvas").getContext("2d");
 			b["mozImageSmoothingEnabled"] = b["webkitImageSmoothingEnabled"] = b["msImageSmoothingEnabled"] = b["imageSmoothingEnabled"] = gq;
 			if (gq) {
 				b["imageSmoothingQuality"] = "high";
@@ -748,12 +746,12 @@ OSurface.prototype = {
     }, createRegularPolygon: function (b, a) {
         this.deleteAllPoints();
         var d = 6.283185307 / a;
-        for (i = 0; i < a; i++) {
+        for (var i = 0; i < a; i++) {
             this.addPoint(Math.cos(d * i) * b, Math.sin(d * i) * b);
         }
     }, createStar: function (b, a, d) {
         var c = 6.283185307 / (2 * d);
-        for (i = 0; i < 2 * d; i++) {
+        for (var i = 0; i < 2 * d; i++) {
             if (0 == i % 2) {
                 var f = Math.cos(c * i) * b;
                 var g = Math.sin(c * i) * b;
@@ -981,7 +979,7 @@ OSurface.prototype = {
         }
     }, operation: function (b, a, d) {
         "/" != b && "%" != b || 0 != d || (d = 0.001);
-        newVal = a;
+        var newVal = a;
         switch (b) {
             case "+":
                 newVal = a + d;
@@ -1991,7 +1989,7 @@ CRunSurface.prototype = CServices.extend(new CRunExtension, {
                 break;
             case CRunSurface.ACT_ADD_BACKDROP:
                 e = a.getParamAltValue(this.rh, 0);
-                imgCanvas = this.oSurf.imageList[this.oSurf.selectedImage].canvas;
+                var imgCanvas = this.oSurf.imageList[this.oSurf.selectedImage].canvas;
                 k = new CImage;
                 c = new Image;
                 c.src = imgCanvas.toDataURL();

--- a/src/Surface.js
+++ b/src/Surface.js
@@ -217,7 +217,7 @@ OSurface.prototype = {
         *********************************************************************************/
         /*var newImage = new CImage();
         newImage.width = context.canvas.width;
-        newImage.height = context.canvas.height;   
+        newImage.height = context.canvas.height;
         var img = new Image();
         img.src = context.canvas.toDataURL();
         newImage.img = img;
@@ -423,7 +423,7 @@ OSurface.prototype = {
         var oldRed = (oldColor >>> 16) & 0xFF,
             oldGreen = (oldColor >>> 8) & 0xFF,
             oldBlue = oldColor & 0xFF
-        newRed = (newColor >>> 16) & 0xFF,
+        var newRed = (newColor >>> 16) & 0xFF,
             newGreen = (newColor >>> 8) & 0xFF,
             newBlue = newColor & 0xFF;
 
@@ -961,7 +961,7 @@ OSurface.prototype = {
 
         var tempContext = document.createElement("canvas").getContext("2d");
         if ((patternName == CServices.getColorString(this.imageList[this.selectedImage].transparentColor))) {
-            //tempContext.globalAlpha = 1; 
+            //tempContext.globalAlpha = 1;
             this.context["globalCompositeOperation"] = "destination-out";
         }
         borderSize *= 0.6; // Fix to display same as windows runtime
@@ -1672,7 +1672,7 @@ OSurface.prototype = {
         this.deleteAllPoints();
         var step = (2 * 3.1415926535) / nbEdges;
 
-        for (i = 0; i < nbEdges; i++) {
+        for (var i = 0; i < nbEdges; i++) {
             var xPos, yPos;
             xPos = (Math.cos(step * i) * radius);
             yPos = (Math.sin(step * i) * radius);
@@ -1684,7 +1684,7 @@ OSurface.prototype = {
     createStar(innerRadius, outerRadius, nbPikes) {
         var step = (2 * 3.1415926535) / (nbPikes * 2);
 
-        for (i = 0; i < nbPikes * 2; i++) {
+        for (var i = 0; i < nbPikes * 2; i++) {
             var xPos, yPos;
 
             if (i % 2 == 0) {
@@ -2064,7 +2064,7 @@ OSurface.prototype = {
         if ((op == '/' || op == '%') && value == 0) {
             value = 0.001;
         }
-        newVal = pixel;
+        var newVal = pixel;
         switch (op) {
             case '+':
                 newVal = pixel + value;
@@ -2244,7 +2244,7 @@ CRunSurface.ACT_DRAW_ELLIPSE_WITH_SIZE_AND_COLOR_THICKNESS = 101; // OK
 CRunSurface.ACT_DRAW_ELLIPSE_WITH_SIZE_AND_PATTERN = 102; // OK
 CRunSurface.ACT_CREATE_REGULAR_POLYGON = 103; // OK
 CRunSurface.ACT_SKYP_REDRAW = 104; // OK
-CRunSurface.ACT_SET_BLIT_DESTINATION = 105; // OK 
+CRunSurface.ACT_SET_BLIT_DESTINATION = 105; // OK
 CRunSurface.ACT_CONVERT_TO_GRAYSCALE = 106; // OK
 CRunSurface.ACT_CREATE_RADIAL_GRADIENT_PATTERN = 107; // OK
 CRunSurface.ACT_SET_BLIT_EFFECT = 108; // NOT IMPLEMENTED
@@ -2379,7 +2379,7 @@ CRunSurface.EXP_IMG_HOT_X = 60; // OK
 CRunSurface.EXP_IMG_HOT_Y = 61; // OK
 CRunSurface.EXP_HOT_X = 62; // OK
 CRunSurface.EXP_HOT_Y = 63; // OK
-CRunSurface.EXP_IMG_TRANSP_COLOR = 64; // OK 
+CRunSurface.EXP_IMG_TRANSP_COLOR = 64; // OK
 CRunSurface.EXP_CALLBACK_DEST_ALPHA = 65; // OK
 CRunSurface.EXP_ADD = 66; // OK
 CRunSurface.EXP_SUBSTRACT = 67; // OK
@@ -2488,7 +2488,7 @@ CRunSurface.prototype = CServices.extend(new CRunExtension(),
             this.oSurf.selectLast = file.readAByte() == 1;
 
             // Font Text
-            file.skipBytes(3); // WHY ? 
+            file.skipBytes(3); // WHY ?
             var font = this.ho.hoAdRunHeader.rhApp.bUnicode ? file.readLogFont() : file.readLogFont16();
             this.oSurf.textParams.family = font.lfFaceName;
             this.oSurf.textParams.size = font.lfHeight + "pt";
@@ -3433,7 +3433,7 @@ CRunSurface.prototype = CServices.extend(new CRunExtension(),
 
                 case CRunSurface.ACT_ADD_BACKDROP:
                     var options = act.getParamAltValue(this.rh, 0);
-                    imgCanvas = this.oSurf.imageList[this.oSurf.selectedImage].canvas;
+                    var imgCanvas = this.oSurf.imageList[this.oSurf.selectedImage].canvas;
                     var cImage = new CImage;
                     var image = new Image();
                     image.src = imgCanvas.toDataURL();

--- a/src/Surface.js
+++ b/src/Surface.js
@@ -669,8 +669,7 @@ OSurface.prototype = {
     },
 
     setAngle(degrees) {
-
-        img.rotation = degrees;
+        this.imageList[this.selectedImage].rotation = degrees;
         this.redraw();
     },
 


### PR DESCRIPTION
Hi

New Fusion build 296.1 added the ability to change the Google Closure compiler used when building as HTML5 Final project.
New compiler versions are more strict, so this PR makes some changes to get it to compile with closure v20250706.

One of the errors caught by the new compiler is that `set angle` action was broken.
Most of the remaining errors were about missing `var`s.
Also, not sure what happend [here](https://github.com/Oviglo/F2-Surface-HTML5/blob/ee2fd1fb3d5a2a40db8688855f26943502b2fc5a/dist/Data/Runtime/Html5/Surface.js#L634), but this didn't build at all, even with the default compiler.